### PR TITLE
use factory pattern for db handle, which enables parallel test

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "cSpell.words": [
+        "dtree",
+        "importee"
+    ]
+}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -38,7 +38,7 @@ var addCmd = &cobra.Command{
 		)
 
 		// load repos from DB
-		repos, err := db.ReadRepos()
+		repos, err := dbHandle.ReadRepos()
 		if err != nil {
 			fmt.Printf("failed to read repos from DB: %v", err)
 			os.Exit(1)
@@ -76,7 +76,7 @@ var addCmd = &cobra.Command{
 			}
 		}
 
-		db.CreateRepos(newRepos)
+		dbHandle.CreateRepos(newRepos)
 	},
 }
 

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/nosarthur/dtree/db"
 	"github.com/nosarthur/dtree/git"
 	"github.com/nosarthur/tree"
 	"github.com/spf13/cobra"
@@ -35,7 +34,7 @@ var lsCmd = &cobra.Command{
 			reposToDelete, hashAndMsg []string
 		)
 
-		repos, err := db.ReadRepos()
+		repos, err := dbHandle.ReadRepos()
 		if err != nil {
 			fmt.Printf("failed to read repos from DB: %v", err)
 			os.Exit(1)
@@ -49,7 +48,7 @@ var lsCmd = &cobra.Command{
 			fmt.Printf("%-18s %s%s", *repo.Name, tree.Colorize(hashAndMsg[0], tree.Blue), hashAndMsg[1])
 		}
 		if len(reposToDelete) > 0 {
-			db.DeleteRepos(reposToDelete)
+			dbHandle.DeleteRepos(reposToDelete)
 		}
 
 	},

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"github.com/nosarthur/dtree/db"
 	"github.com/spf13/cobra"
 )
 
@@ -25,7 +24,7 @@ var rmCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Short: "Remove git repo(s)",
 	Run: func(cmd *cobra.Command, args []string) {
-		db.DeleteRepos(args)
+		dbHandle.DeleteRepos(args)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,12 +17,16 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/nosarthur/dtree/db"
 	"github.com/spf13/cobra"
 )
 
-var cfgFile string
+var (
+	dbHandle db.Handle
+)
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -41,6 +45,12 @@ func Execute() {
 }
 
 func init() {
-	// create the DB if necessary and then connect to it
-	db.MustInit("")
+	// create the DB at home directory if not present and then connect to it
+	home, err := homedir.Dir()
+	if err != nil {
+		fmt.Printf("failed to get home directory: %v", err)
+		os.Exit(1)
+	}
+	dbPath := filepath.Join(home, "./dtree.db")
+	dbHandle = db.MustInit(dbPath)
 }

--- a/db/api.go
+++ b/db/api.go
@@ -3,9 +3,9 @@ package db
 import "fmt"
 
 // CreateRepos writes to DB
-func CreateRepos(rs []Repo) {
+func (h Handle) CreateRepos(rs []Repo) {
 	for _, repo := range rs {
-		_, err := conn.NamedExec(insertRepo, repo)
+		_, err := h.NamedExec(insertRepo, repo)
 		if err != nil {
 			fmt.Printf("fail to add repo %s to DB: %v\n", *repo.Name, err)
 		}
@@ -13,9 +13,9 @@ func CreateRepos(rs []Repo) {
 }
 
 // ReadRepos returns all repos in DB
-func ReadRepos() ([]Repo, error) {
+func (h Handle) ReadRepos() ([]Repo, error) {
 	repos := []Repo{}
-	err := conn.Select(&repos, "SELECT * FROM repo ORDER BY name ASC")
+	err := h.Select(&repos, "SELECT * FROM repo ORDER BY name ASC")
 	if err != nil {
 		return nil, fmt.Errorf("fail to read repos from DB: %v", err)
 	}
@@ -23,9 +23,9 @@ func ReadRepos() ([]Repo, error) {
 }
 
 // DeleteRepos deletes the selected repos
-func DeleteRepos(names []string) {
+func (h Handle) DeleteRepos(names []string) {
 	for _, name := range names {
-		_, err := conn.Exec("DELETE FROM repo WHERE name=$1", name)
+		_, err := h.Exec("DELETE FROM repo WHERE name=$1", name)
 		if err != nil {
 			fmt.Printf("fail to delete repo %s: %v", name, err)
 			continue

--- a/db/api_test.go
+++ b/db/api_test.go
@@ -12,9 +12,9 @@ func TestRepoAPI(t *testing.T) {
 	testdb, teardown := setup(t)
 	defer teardown()
 
-	db.MustInit(testdb)
+	h := db.MustInit(testdb)
 	// read
-	repos, err := db.ReadRepos()
+	repos, err := h.ReadRepos()
 	require.Nil(t, err, "fail to read repos")
 	assert.Empty(t, repos, "DB is not empty")
 
@@ -23,13 +23,13 @@ func TestRepoAPI(t *testing.T) {
 	path := "test path"
 	msg := "test msg"
 	r := db.Repo{&name, &path, &msg}
-	db.CreateRepos([]db.Repo{r})
-	repos, err = db.ReadRepos()
+	h.CreateRepos([]db.Repo{r})
+	repos, err = h.ReadRepos()
 	assert.Equal(t, 1, len(repos))
 	assert.Equal(t, repos[0], r)
 
 	// delete
-	db.DeleteRepos([]string{name})
-	repos, err = db.ReadRepos()
+	h.DeleteRepos([]string{name})
+	repos, err = h.ReadRepos()
 	assert.Empty(t, repos, "DB is not empty")
 }

--- a/db/schema_test.go
+++ b/db/schema_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func setup(t *testing.T) (string, func()) {
-	//	t.Parallel()
+	t.Parallel()
 
 	const testdb = "test.db"
 	dir, err := ioutil.TempDir("", "")


### PR DESCRIPTION
The `db` package used to have a global variable to hold `*sqlx.DB`. Now the `cmd` package has a global variable to hold `db.Handle`